### PR TITLE
Revert crd graduation

### DIFF
--- a/helm/azure-app-collection-chart/templates/azure-operator-3.0.7.yaml
+++ b/helm/azure-app-collection-chart/templates/azure-operator-3.0.7.yaml
@@ -1,0 +1,42 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  annotations:
+    chart-operator.giantswarm.io/force-helm-upgrade: "true"
+  creationTimestamp: null
+  labels:
+    app-operator.giantswarm.io/version: 1.0.0
+  name: azure-operator-3.0.7
+  namespace: giantswarm
+spec:
+  catalog: control-plane-catalog
+  config:
+    configMap:
+      name: ""
+      namespace: ""
+    secret:
+      name: ""
+      namespace: ""
+  kubeConfig:
+    context:
+      name: ""
+    inCluster: true
+    secret:
+      name: ""
+      namespace: ""
+  name: azure-operator
+  namespace: giantswarm
+  userConfig:
+    configMap:
+      name: ""
+      namespace: ""
+    secret:
+      name: ""
+      namespace: ""
+  version: 3.0.7
+status:
+  appVersion: ""
+  release:
+    lastDeployed: null
+    status: ""
+  version: ""


### PR DESCRIPTION
I got this error

```
#!/bin/bash -eo pipefail
[ ! -f .build_tagged_operator_build ] && echo "skip: not tagged operator build" && exit 0
git diff --exit-code --no-index .build_operator_version .build_chart_version
diff --git a/.build_operator_version b/.build_chart_version
index 2451c27c..4bf583f1 100644
--- a/.build_operator_version
+++ b/.build_chart_version
@@ -1 +1 @@
-3.0.7
+3.0.7-1

Exited with code exit status 1
CircleCI received exit code 1
```