### PR TITLE
Use release required when deploying using app collection

### DIFF
--- a/flux-manifests/cluster-apps-operator.yaml
+++ b/flux-manifests/cluster-apps-operator.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-apps-operator
-app_version: 0.6.1
+app_version: 1.1.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
[According to the operator changelog](https://github.com/giantswarm/cluster-apps-operator/blob/master/CHANGELOG.md#110---2021-12-08) we need to use this version when deploying using the app collection.