### PR TITLE
Cluster Autoscaler: Bump to v1.24.3-gs6.

### DIFF
--- a/flux-manifests/cluster-autoscaler-app.yaml
+++ b/flux-manifests/cluster-autoscaler-app.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: kube-system
 app_name: cluster-autoscaler-app
-app_version: 1.23.1
+app_version: 1.24.3-gs6
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
Changelog: https://github.com/giantswarm/cluster-autoscaler-app/blob/release-v1.24.x/CHANGELOG.md
Comparison: https://github.com/giantswarm/cluster-autoscaler-app/compare/v1.23.1...v1.24.3-gs6

Towards https://github.com/giantswarm/giantswarm/issues/30063.