### PR TITLE
Revert "update cluster-autoscaler-app to 1.27.3-gs10"

### DIFF
--- a/flux-manifests/cluster-autoscaler-app.yaml
+++ b/flux-manifests/cluster-autoscaler-app.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: kube-system
 app_name: cluster-autoscaler-app
-app_version: 1.27.3-gs10
+app_version: 1.24.3-gs6
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
This reverts commit c117d0420621c1944a8a1a0d2d1e5636d523c6dd, so vintage MCs keep using 1.25.3-gs2